### PR TITLE
Fix JavaDoc warnings across Atlassian data store and API classes

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/atlassian/AtlassianDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/AtlassianDataStore.java
@@ -34,26 +34,56 @@ import org.codelibs.fess.ds.AbstractDataStore;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * Abstract base class for Atlassian data stores providing common functionality
+ * for crawling JIRA and Confluence instances.
+ */
 public abstract class AtlassianDataStore extends AbstractDataStore {
+
+    /**
+     * Default constructor for Atlassian data store.
+     */
+    protected AtlassianDataStore() {
+        super();
+    }
 
     private static final Logger logger = LogManager.getLogger(AtlassianDataStore.class);
 
+    /** MIME type constant for HTML content. */
     protected static final String MIMETYPE_HTML = "text/html";
 
     // parameters
+    /** Parameter key for ignoring errors during crawling. */
     protected static final String IGNORE_ERROR = "ignore_error";
+    /** Parameter key for URL include patterns. */
     protected static final String INCLUDE_PATTERN = "include_pattern";
+    /** Parameter key for URL exclude patterns. */
     protected static final String EXCLUDE_PATTERN = "exclude_pattern";
+    /** Parameter key for URL filter configuration. */
     protected static final String URL_FILTER = "url_filter";
+    /** Parameter key for number of threads configuration. */
     protected static final String NUMBER_OF_THREADS = "number_of_threads";
+    /** Parameter key for read interval configuration. */
     protected static final String READ_INTERVAL = "read_interval";
 
+    /** Name of the text extractor to use for content processing. */
     protected String extractorName = "tikaExtractor";
 
+    /**
+     * Sets the name of the text extractor.
+     *
+     * @param extractorName the extractor name to set
+     */
     public void setExtractorName(final String extractorName) {
         this.extractorName = extractorName;
     }
 
+    /**
+     * Creates and configures a URL filter based on the provided parameters.
+     *
+     * @param paramMap the parameter map containing filter configuration
+     * @return configured URL filter
+     */
     protected UrlFilter getUrlFilter(final DataStoreParams paramMap) {
         final UrlFilter urlFilter = ComponentUtil.getComponent(UrlFilter.class);
         final String include = paramMap.getAsString(INCLUDE_PATTERN);
@@ -71,6 +101,12 @@ public abstract class AtlassianDataStore extends AbstractDataStore {
         return urlFilter;
     }
 
+    /**
+     * Creates a new fixed thread pool executor.
+     *
+     * @param nThreads the number of threads in the pool
+     * @return the configured executor service
+     */
     protected ExecutorService newFixedThreadPool(final int nThreads) {
         if (logger.isDebugEnabled()) {
             logger.debug("Executor Thread Pool: {}", nThreads);
@@ -79,14 +115,32 @@ public abstract class AtlassianDataStore extends AbstractDataStore {
                 new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
+    /**
+     * Gets the number of threads from the parameter map.
+     *
+     * @param paramMap the parameter map
+     * @return the number of threads, defaults to 1
+     */
     protected Integer getNumberOfThreads(final DataStoreParams paramMap) {
         return Integer.parseInt(paramMap.getAsString(NUMBER_OF_THREADS, "1"));
     }
 
+    /**
+     * Checks if errors should be ignored during crawling.
+     *
+     * @param paramMap the parameter map
+     * @return true if errors should be ignored, false otherwise
+     */
     protected boolean isIgnoreError(final DataStoreParams paramMap) {
         return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_ERROR, Constants.TRUE));
     }
 
+    /**
+     * Creates a configuration map from the provided parameters.
+     *
+     * @param paramMap the parameter map
+     * @return the configuration map
+     */
     protected Map<String, Object> createConfigMap(final DataStoreParams paramMap) {
         final Map<String, Object> configMap = new HashMap<>();
         configMap.put(IGNORE_ERROR, isIgnoreError(paramMap));
@@ -95,10 +149,23 @@ public abstract class AtlassianDataStore extends AbstractDataStore {
         return configMap;
     }
 
+    /**
+     * Extracts text content from HTML.
+     *
+     * @param body the HTML content
+     * @return the extracted text
+     */
     public String getExtractedTextFromHtml(final String body) {
         return getExtractedText(body, MIMETYPE_HTML);
     }
 
+    /**
+     * Extracts text content from the given text using the specified MIME type.
+     *
+     * @param text the content to extract text from
+     * @param mimeType the MIME type of the content
+     * @return the extracted text
+     */
     public String getExtractedText(final String text, final String mimeType) {
         try (final InputStream in = new ByteArrayInputStream(text.getBytes())) {
             return ComponentUtil.getExtractorFactory().builder(in, null).mimeType(mimeType).extractorName(extractorName).extract()

--- a/src/main/java/org/codelibs/fess/ds/atlassian/AtlassianDataStoreException.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/AtlassianDataStoreException.java
@@ -17,18 +17,37 @@ package org.codelibs.fess.ds.atlassian;
 
 import org.codelibs.fess.exception.DataStoreException;
 
+/**
+ * Exception thrown when errors occur during Atlassian data store operations.
+ */
 public class AtlassianDataStoreException extends DataStoreException {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause the cause of this exception
+     */
     public AtlassianDataStoreException(final String message, final Throwable cause) {
         super(message, cause);
     }
 
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message the detail message
+     */
     public AtlassianDataStoreException(final String message) {
         super(message);
     }
 
+    /**
+     * Constructs a new exception with the specified cause.
+     *
+     * @param cause the cause of this exception
+     */
     public AtlassianDataStoreException(final Throwable cause) {
         super(cause);
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/ConfluenceDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/ConfluenceDataStore.java
@@ -40,17 +40,39 @@ import org.codelibs.fess.helper.CrawlerStatsHelper.StatsKeyObject;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * Data store implementation for crawling Confluence content.
+ * Retrieves pages, blog posts, and their comments from Confluence instances and indexes them in Fess.
+ */
 public class ConfluenceDataStore extends AtlassianDataStore {
 
+    /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(ConfluenceDataStore.class);
 
     // scripts
+    /** Script variable name for content data. */
     protected static final String CONTENT = "content";
+
+    /** Script variable name for content title. */
     protected static final String CONTENT_TITLE = "title";
+
+    /** Script variable name for content body. */
     protected static final String CONTENT_BODY = "body";
+
+    /** Script variable name for content comments. */
     protected static final String CONTENT_COMMENTS = "comments";
+
+    /** Script variable name for content last modified date. */
     protected static final String CONTENT_LAST_MODIFIED = "last_modified";
+
+    /** Script variable name for content view URL. */
     protected static final String CONTENT_VIEW_URL = "view_url";
+
+    /**
+     * Default constructor.
+     */
+    public ConfluenceDataStore() {
+    }
 
     @Override
     protected String getName() {
@@ -86,10 +108,28 @@ public class ConfluenceDataStore extends AtlassianDataStore {
         }
     }
 
+    /**
+     * Creates a Confluence client with the given parameters.
+     *
+     * @param paramMap the data store parameters
+     * @return the configured Confluence client
+     */
     protected ConfluenceClient createClient(final DataStoreParams paramMap) {
         return new ConfluenceClient(paramMap);
     }
 
+    /**
+     * Processes a single Confluence content item and indexes it.
+     *
+     * @param dataConfig the data configuration
+     * @param callback the index update callback
+     * @param configMap the configuration map
+     * @param paramMap the parameter map
+     * @param scriptMap the script map
+     * @param defaultDataMap the default data map
+     * @param client the Confluence client
+     * @param content the content to process
+     */
     protected void processContent(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final ConfluenceClient client, final Content content) {
@@ -181,6 +221,13 @@ public class ConfluenceDataStore extends AtlassianDataStore {
         }
     }
 
+    /**
+     * Gets all comments for a Confluence content item as concatenated text.
+     *
+     * @param content the Confluence content
+     * @param client the Confluence client
+     * @return the concatenated comments text
+     */
     protected String getContentComments(final Content content, final ConfluenceClient client) {
         final StringBuilder sb = new StringBuilder();
         final String id = content.getId();
@@ -193,10 +240,23 @@ public class ConfluenceDataStore extends AtlassianDataStore {
         return sb.toString();
     }
 
+    /**
+     * Converts a timestamp to a Date object.
+     *
+     * @param date the timestamp in seconds
+     * @return the Date object
+     */
     protected Date getLastModifiedAsDate(final Long date) {
         return new Date(date * 1000L);
     }
 
+    /**
+     * Gets the view URL for a Confluence content item.
+     *
+     * @param content the Confluence content
+     * @param confluenceHome the Confluence home URL
+     * @return the content view URL
+     */
     protected String getContentViewUrl(final Content content, final String confluenceHome) {
         return confluenceHome + "/pages/viewpage.action?pageId=" + content.getId();
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/JiraDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/JiraDataStore.java
@@ -43,17 +43,39 @@ import org.codelibs.fess.helper.CrawlerStatsHelper.StatsKeyObject;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 
+/**
+ * Data store implementation for crawling JIRA issues.
+ * Retrieves issues and their comments from JIRA instances and indexes them in Fess.
+ */
 public class JiraDataStore extends AtlassianDataStore {
 
+    /** Logger instance for this class. */
     private static final Logger logger = LogManager.getLogger(JiraDataStore.class);
 
     // scripts
+    /** Script variable name for issue data. */
     protected static final String ISSUE = "issue";
+
+    /** Script variable name for issue summary. */
     protected static final String ISSUE_SUMMARY = "summary";
+
+    /** Script variable name for issue description. */
     protected static final String ISSUE_DESCRIPTION = "description";
+
+    /** Script variable name for issue comments. */
     protected static final String ISSUE_COMMENTS = "comments";
+
+    /** Script variable name for issue last modified date. */
     protected static final String ISSUE_LAST_MODIFIED = "last_modified";
+
+    /** Script variable name for issue view URL. */
     protected static final String ISSUE_VIEW_URL = "view_url";
+
+    /**
+     * Default constructor.
+     */
+    public JiraDataStore() {
+    }
 
     @Override
     protected String getName() {
@@ -87,10 +109,28 @@ public class JiraDataStore extends AtlassianDataStore {
         }
     }
 
+    /**
+     * Creates a JIRA client with the given parameters.
+     *
+     * @param paramMap the data store parameters
+     * @return the configured JIRA client
+     */
     protected JiraClient createClient(final DataStoreParams paramMap) {
         return new JiraClient(paramMap);
     }
 
+    /**
+     * Processes a single JIRA issue and indexes it.
+     *
+     * @param dataConfig the data configuration
+     * @param callback the index update callback
+     * @param configMap the configuration map
+     * @param paramMap the parameter map
+     * @param scriptMap the script map
+     * @param defaultDataMap the default data map
+     * @param client the JIRA client
+     * @param issue the issue to process
+     */
     protected void processIssue(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
             final JiraClient client, final Issue issue) {
@@ -181,10 +221,24 @@ public class JiraDataStore extends AtlassianDataStore {
         }
     }
 
+    /**
+     * Gets the view URL for a JIRA issue.
+     *
+     * @param issue the JIRA issue
+     * @param client the JIRA client
+     * @return the issue view URL
+     */
     protected String getIssueViewUrl(final Issue issue, final JiraClient client) {
         return client.getJiraHome() + "/browse/" + issue.getKey();
     }
 
+    /**
+     * Gets all comments for a JIRA issue as concatenated text.
+     *
+     * @param issue the JIRA issue
+     * @param client the JIRA client
+     * @return the concatenated comments text
+     */
     protected String getIssueComments(final Issue issue, final JiraClient client) {
         final StringBuilder sb = new StringBuilder();
         final String id = issue.getId();
@@ -197,6 +251,12 @@ public class JiraDataStore extends AtlassianDataStore {
         return sb.toString();
     }
 
+    /**
+     * Gets the last modified date of a JIRA issue.
+     *
+     * @param issue the JIRA issue
+     * @return the last modified date, or null if parsing fails
+     */
     protected Date getIssueLastModified(final Issue issue) {
         final String updated = issue.getFields().getUpdated();
         try {

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/AtlassianClient.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/AtlassianClient.java
@@ -24,32 +24,58 @@ import org.codelibs.fess.ds.atlassian.api.authentication.BasicAuthentication;
 import org.codelibs.fess.ds.atlassian.api.authentication.OAuthAuthentication;
 import org.codelibs.fess.entity.DataStoreParams;
 
+/**
+ * Abstract base class for Atlassian API clients providing common authentication
+ * and HTTP configuration functionality.
+ */
 public abstract class AtlassianClient {
 
     private static final Logger logger = LogManager.getLogger(AtlassianClient.class);
 
     // parameters
+    /** Parameter key for the Atlassian instance home URL. */
     protected static final String HOME_PARAM = "home";
+    /** Parameter key for authentication type selection. */
     protected static final String AUTH_TYPE_PARAM = "auth_type";
+    /** Parameter key for OAuth consumer key. */
     protected static final String CONSUMER_KEY_PARAM = "oauth.consumer_key";
+    /** Parameter key for OAuth private key. */
     protected static final String PRIVATE_KEY_PARAM = "oauth.private_key";
+    /** Parameter key for OAuth secret/verifier. */
     protected static final String SECRET_PARAM = "oauth.secret";
+    /** Parameter key for OAuth access token. */
     protected static final String ACCESS_TOKEN_PARAM = "oauth.access_token";
+    /** Parameter key for basic authentication username. */
     protected static final String BASIC_USERNAME_PARAM = "basic.username";
+    /** Parameter key for basic authentication password. */
     protected static final String BASIC_PASS_PARAM = "basic.password";
+    /** Parameter key for HTTP proxy host. */
     protected static final String PROXY_HOST_PARAM = "proxy_host";
+    /** Parameter key for HTTP proxy port. */
     protected static final String PROXY_PORT_PARAM = "proxy_port";
+    /** Parameter key for HTTP connection timeout. */
     protected static final String HTTP_CONNECTION_TIMEOUT = "connection_timeout";
+    /** Parameter key for HTTP read timeout. */
     protected static final String HTTP_READ_TIMEOUT = "read_timeout";
 
     // values for parameters
+    /** Authentication type constant for basic authentication. */
     protected static final String BASIC = "basic";
+    /** Authentication type constant for OAuth authentication. */
     protected static final String OAUTH = "oauth";
 
+    /** The authentication instance used for API requests. */
     protected Authentication authentication;
+    /** HTTP connection timeout in milliseconds. */
     protected Integer connectionTimeout;
+    /** HTTP read timeout in milliseconds. */
     protected Integer readTimeout;
 
+    /**
+     * Constructs a new Atlassian client with the given parameters.
+     *
+     * @param paramMap the configuration parameters
+     */
     protected AtlassianClient(final DataStoreParams paramMap) {
 
         final String home = getHome(paramMap);
@@ -110,6 +136,13 @@ public abstract class AtlassianClient {
         }
     }
 
+    /**
+     * Configures a request with authentication and timeout settings.
+     *
+     * @param <T> the request type
+     * @param request the request to configure
+     * @return the configured request
+     */
     protected <T extends AtlassianRequest> T createRequest(final T request) {
         request.setAuthentication(authentication);
         request.setAppHome(getAppHome());
@@ -118,8 +151,19 @@ public abstract class AtlassianClient {
         return request;
     }
 
+    /**
+     * Gets the application home URL.
+     *
+     * @return the application home URL
+     */
     protected abstract String getAppHome();
 
+    /**
+     * Gets the home URL from the parameter map.
+     *
+     * @param paramMap the parameter map
+     * @return the home URL
+     */
     protected String getHome(final DataStoreParams paramMap) {
         return paramMap.getAsString(HOME_PARAM, StringUtil.EMPTY);
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/AtlassianRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/AtlassianRequest.java
@@ -32,41 +32,90 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import net.minidev.json.JSONObject;
 
+/**
+ * Abstract base class for Atlassian API requests providing common HTTP functionality.
+ */
 public abstract class AtlassianRequest {
+
+    /**
+     * Default constructor for Atlassian request.
+     */
+    protected AtlassianRequest() {
+        // Default constructor
+    }
 
     private static final Logger logger = LogManager.getLogger(AtlassianRequest.class);
 
+    /** JSON object mapper for request/response serialization. */
     protected static final ObjectMapper mapper = new ObjectMapper();
 
+    /** HTTP GET method constant. */
     protected static final String GET = "GET";
+    /** HTTP POST method constant. */
     protected static final String POST = "POST";
+    /** HTTP PUT method constant. */
     protected static final String PUT = "PUT";
+    /** HTTP DELETE method constant. */
     protected static final String DELETE = "DELETE";
 
+    /** Function to create GET curl requests. */
     protected static final Function<String, CurlRequest> CURL_GET = Curl::get;
+    /** Function to create POST curl requests. */
     protected static final Function<String, CurlRequest> CURL_POST = Curl::post;
+    /** Function to create PUT curl requests. */
     protected static final Function<String, CurlRequest> CURL_PUT = Curl::put;
+    /** Function to create DELETE curl requests. */
     protected static final Function<String, CurlRequest> CURL_DELETE = Curl::delete;
 
+    /** Authentication instance for API requests. */
     protected Authentication authentication;
+    /** Application home URL. */
     protected String appHome;
+    /** HTTP connection timeout in milliseconds. */
     protected Integer connectionTimeout;
+    /** HTTP read timeout in milliseconds. */
     protected Integer readTimeout;
 
+    /**
+     * Gets the application home URL.
+     *
+     * @return the application home URL
+     */
     public String appHome() {
         return appHome;
     }
 
+    /**
+     * Gets the complete URL for this request.
+     *
+     * @return the request URL
+     */
     public abstract String getURL();
 
+    /**
+     * Gets the query parameters for this request.
+     *
+     * @return the query parameter map, or null if no parameters
+     */
     public Map<String, String> getQueryParamMap() {
         return null;
     }
 
+    /**
+     * Gets the request body parameters.
+     *
+     * @return the body parameter map, or null if no body
+     */
     public Map<String, Object> getBodyMap() {
         return null;
     }
 
+    /**
+     * Executes the HTTP request using the specified method.
+     *
+     * @param requestMethod the HTTP method to use
+     * @return the HTTP response
+     */
     public CurlResponse getCurlResponse(final String requestMethod) {
         switch (requestMethod) {
         case GET:
@@ -83,6 +132,13 @@ public abstract class AtlassianRequest {
         }
     }
 
+    /**
+     * Executes the HTTP request using the specified curl method function.
+     *
+     * @param method the curl method function
+     * @param requestMethod the HTTP method name
+     * @return the HTTP response
+     */
     public CurlResponse getCurlResponse(final Function<String, CurlRequest> method, final String requestMethod) {
         try {
             final StringBuilder urlBuf = new StringBuilder();
@@ -119,18 +175,38 @@ public abstract class AtlassianRequest {
         }
     }
 
+    /**
+     * Sets the authentication for this request.
+     *
+     * @param authentication the authentication instance
+     */
     public void setAuthentication(final Authentication authentication) {
         this.authentication = authentication;
     }
 
+    /**
+     * Sets the application home URL.
+     *
+     * @param appHome the application home URL
+     */
     public void setAppHome(final String appHome) {
         this.appHome = appHome;
     }
 
+    /**
+     * Sets the HTTP connection timeout.
+     *
+     * @param connectionTimeout the connection timeout in milliseconds
+     */
     public void setConnectionTimeout(final Integer connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
     }
 
+    /**
+     * Sets the HTTP read timeout.
+     *
+     * @param readTimeout the read timeout in milliseconds
+     */
     public void setReadTimeout(final Integer readTimeout) {
         this.readTimeout = readTimeout;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/Authentication.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/Authentication.java
@@ -22,14 +22,39 @@ import java.util.function.Function;
 
 import org.codelibs.curl.CurlRequest;
 
+/**
+ * Abstract base class for Atlassian API authentication methods.
+ */
 public abstract class Authentication {
 
+    /**
+     * Default constructor for authentication.
+     */
+    protected Authentication() {
+        // Default constructor
+    }
+
+    /** HTTP proxy configuration. */
     protected Proxy httpProxy;
 
+    /**
+     * Sets the HTTP proxy configuration.
+     *
+     * @param httpProxyHost the proxy host
+     * @param httpProxyPort the proxy port
+     */
     public void setHttpProxy(final String httpProxyHost, final Integer httpProxyPort) {
         this.httpProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(httpProxyHost, httpProxyPort));
     }
 
+    /**
+     * Creates an authenticated curl request.
+     *
+     * @param request the curl request function
+     * @param requestMethod the HTTP method
+     * @param url the target URL
+     * @return the authenticated curl request
+     */
     public abstract CurlRequest getCurlRequest(final Function<String, CurlRequest> request, final String requestMethod, final URL url);
 
 }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/BasicAuthentication.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/BasicAuthentication.java
@@ -21,11 +21,22 @@ import java.util.function.Function;
 
 import org.codelibs.curl.CurlRequest;
 
+/**
+ * Basic authentication implementation using username and password.
+ */
 public class BasicAuthentication extends Authentication {
 
+    /** The username for authentication. */
     protected final String username;
+    /** The password for authentication. */
     protected final String password;
 
+    /**
+     * Constructs a new basic authentication with the given credentials.
+     *
+     * @param username the username
+     * @param password the password
+     */
     public BasicAuthentication(final String username, final String password) {
         this.username = username;
         this.password = password;
@@ -42,6 +53,12 @@ public class BasicAuthentication extends Authentication {
         return request;
     }
 
+    /**
+     * Base64 encodes the given string.
+     *
+     * @param s the string to encode
+     * @return the base64 encoded string
+     */
     protected static String encode(final String s) {
         return Base64.getEncoder().encodeToString(s.getBytes());
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/OAuthAuthentication.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/authentication/OAuthAuthentication.java
@@ -22,13 +22,31 @@ import java.util.function.Function;
 import org.codelibs.curl.CurlRequest;
 import org.codelibs.fess.ds.atlassian.api.util.OAuthUtil;
 
+/**
+ * OAuth authentication implementation using consumer key, private key, token, and verifier.
+ */
 public class OAuthAuthentication extends Authentication {
 
+    /** The OAuth consumer key. */
     protected final String consumerKey;
+
+    /** The OAuth private key for signing requests. */
     protected final PrivateKey privateKey;
+
+    /** The OAuth access token. */
     protected final String token;
+
+    /** The OAuth verifier. */
     protected final String verifier;
 
+    /**
+     * Constructs a new OAuth authentication with the given parameters.
+     *
+     * @param consumerKey the OAuth consumer key
+     * @param privateKey the OAuth private key (as string)
+     * @param token the OAuth access token
+     * @param verifier the OAuth verifier
+     */
     public OAuthAuthentication(final String consumerKey, final String privateKey, final String token, final String verifier) {
         this.consumerKey = consumerKey;
         this.privateKey = OAuthUtil.getPrivateKey(privateKey);

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/ConfluenceClient.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/ConfluenceClient.java
@@ -32,16 +32,30 @@ import org.codelibs.fess.ds.atlassian.api.confluence.space.GetSpaceRequest;
 import org.codelibs.fess.ds.atlassian.api.confluence.space.GetSpacesRequest;
 import org.codelibs.fess.entity.DataStoreParams;
 
+/**
+ * Confluence API client for accessing Confluence content, spaces, and comments.
+ * Provides high-level methods for interacting with Confluence REST API.
+ */
 public class ConfluenceClient extends AtlassianClient implements Closeable {
 
+    /** Default limit for content requests. */
     protected static final String DEFAULT_CONTENT_LIMIT = "25";
 
     // parameters for confluence
+    /** Parameter key for content limit configuration. */
     protected static final String CONTENT_LIMIT_PARAM = "content_limit";
 
+    /** The Confluence instance home URL. */
     protected final String confluenceHome;
+
+    /** The maximum number of content items to retrieve per request. */
     protected final Integer contentLimit;
 
+    /**
+     * Constructs a new Confluence client with the specified parameters.
+     *
+     * @param paramMap the configuration parameters
+     */
     public ConfluenceClient(final DataStoreParams paramMap) {
         super(paramMap);
         confluenceHome = getHome(paramMap);
@@ -53,34 +67,79 @@ public class ConfluenceClient extends AtlassianClient implements Closeable {
         // TODO
     }
 
+    /**
+     * Gets the Confluence home URL.
+     *
+     * @return the Confluence home URL
+     */
     public String getConfluenceHome() {
         return confluenceHome;
     }
 
+    /**
+     * Gets the content limit from parameters.
+     *
+     * @param paramMap the parameter map
+     * @return the content limit
+     */
     public Integer getContentLimit(final DataStoreParams paramMap) {
         return Integer.parseInt(paramMap.getAsString(CONTENT_LIMIT_PARAM, DEFAULT_CONTENT_LIMIT));
     }
 
+    /**
+     * Creates a request to get all spaces.
+     *
+     * @return a GetSpacesRequest instance
+     */
     public GetSpacesRequest spaces() {
         return createRequest(new GetSpacesRequest());
     }
 
+    /**
+     * Creates a request to get a specific space.
+     *
+     * @param spaceKey the space key
+     * @return a GetSpaceRequest instance
+     */
     public GetSpaceRequest space(final String spaceKey) {
         return createRequest(new GetSpaceRequest(spaceKey));
     }
 
+    /**
+     * Creates a request to get content.
+     *
+     * @return a GetContentsRequest instance
+     */
     public GetContentsRequest contents() {
         return createRequest(new GetContentsRequest());
     }
 
+    /**
+     * Creates a request to get specific content.
+     *
+     * @param contentId the content ID
+     * @return a GetContentRequest instance
+     */
     public GetContentRequest content(final String contentId) {
         return createRequest(new GetContentRequest(contentId));
     }
 
+    /**
+     * Creates a request to get comments of specific content.
+     *
+     * @param contentId the content ID
+     * @return a GetCommentsOfContentRequest instance
+     */
     public GetCommentsOfContentRequest commentsOfContent(final String contentId) {
         return createRequest(new GetCommentsOfContentRequest(contentId));
     }
 
+    /**
+     * Creates a request to get attachments of specific content.
+     *
+     * @param contentId the content ID
+     * @return a GetAttachmentsOfContentRequest instance
+     */
     public GetAttachmentsOfContentRequest attachmentsOfContent(final String contentId) {
         return createRequest(new GetAttachmentsOfContentRequest(contentId));
     }
@@ -90,6 +149,11 @@ public class ConfluenceClient extends AtlassianClient implements Closeable {
         return confluenceHome;
     }
 
+    /**
+     * Retrieves all content pages using pagination and passes them to the consumer.
+     *
+     * @param consumer the consumer to process each content item
+     */
     public void getContents(final Consumer<Content> consumer) {
         for (int start = 0;; start += contentLimit) {
             final GetContentsResponse response =
@@ -102,6 +166,11 @@ public class ConfluenceClient extends AtlassianClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all blog content using pagination and passes them to the consumer.
+     *
+     * @param consumer the consumer to process each blog content item
+     */
     public void getBlogContents(final Consumer<Content> consumer) {
         for (int start = 0;; start += contentLimit) {
             final GetContentsResponse response =
@@ -114,6 +183,12 @@ public class ConfluenceClient extends AtlassianClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all comments for specific content using pagination and passes them to the consumer.
+     *
+     * @param id the content ID
+     * @param consumer the consumer to process each comment
+     */
     public void getContentComments(final String id, final Consumer<Comment> consumer) {
         for (int start = 0;; start += contentLimit) {
             final GetCommentsOfContentResponse response =

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentRequest.java
@@ -29,6 +29,10 @@ import org.codelibs.fess.ds.atlassian.api.confluence.domain.Content;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+/**
+ * Request class for retrieving Confluence content.
+ * Allows specification of status, version, and fields to expand.
+ */
 public class GetContentRequest extends AtlassianRequest {
 
     private final String id;
@@ -36,25 +40,54 @@ public class GetContentRequest extends AtlassianRequest {
     private Integer version;
     private String[] expand;
 
+    /**
+     * Constructs a request to get Confluence content with the specified ID.
+     *
+     * @param id the content ID
+     */
     public GetContentRequest(final String id) {
         this.id = id;
     }
 
+    /**
+     * Sets the status filter for the content.
+     *
+     * @param status the status to filter by
+     * @return this request instance for method chaining
+     */
     public GetContentRequest status(final String status) {
         this.status = status;
         return this;
     }
 
+    /**
+     * Sets the specific version of the content to retrieve.
+     *
+     * @param version the version number
+     * @return this request instance for method chaining
+     */
     public GetContentRequest version(final int version) {
         this.version = version;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetContentRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing the content
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetContentResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -66,6 +99,13 @@ public class GetContentRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetContentResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetContentResponse(null);

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentResponse.java
@@ -17,14 +17,28 @@ package org.codelibs.fess.ds.atlassian.api.confluence.content;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Content;
 
+/**
+ * Response containing Confluence content.
+ */
 public class GetContentResponse {
 
+    /** The content returned by the API. */
     protected final Content content;
 
+    /**
+     * Constructs a response with the given content.
+     *
+     * @param content the content
+     */
     public GetContentResponse(final Content content) {
         this.content = content;
     }
 
+    /**
+     * Returns the content.
+     *
+     * @return the content
+     */
     public Content getContent() {
         return content;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentsRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentsRequest.java
@@ -31,57 +31,135 @@ import org.codelibs.fess.ds.atlassian.api.confluence.domain.Content;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request for retrieving Confluence content using the REST API.
+ * Supports filtering by type, space, title, status, and pagination.
+ */
 public class GetContentsRequest extends AtlassianRequest {
 
+    /** The content type filter (e.g., page, blogpost). */
     private String type;
+
+    /** The space key filter. */
     private String spaceKey;
+
+    /** The title filter. */
     private String title;
+
+    /** The status filter. */
     private String status;
+
+    /** The posting day filter. */
     private String postingDay;
+
+    /** The expand parameters for additional data. */
     private String[] expand;
+
+    /** The start index for pagination. */
     private Integer start;
+
+    /** The limit for pagination. */
     private Integer limit;
 
+    /**
+     * Default constructor.
+     */
+    public GetContentsRequest() {
+    }
+
+    /**
+     * Sets the content type filter.
+     *
+     * @param type the content type
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest type(final String type) {
         this.type = type;
         return this;
     }
 
+    /**
+     * Sets the space key filter.
+     *
+     * @param spaceKey the space key
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest spaceKey(final String spaceKey) {
         this.spaceKey = spaceKey;
         return this;
     }
 
+    /**
+     * Sets the title filter.
+     *
+     * @param title the title
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest title(final String title) {
         this.title = title;
         return this;
     }
 
+    /**
+     * Sets the status filter.
+     *
+     * @param status the status
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest status(final String status) {
         this.status = status;
         return this;
     }
 
+    /**
+     * Sets the posting day filter.
+     *
+     * @param postingDay the posting day
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest postingDay(final String postingDay) {
         this.postingDay = postingDay;
         return this;
     }
 
+    /**
+     * Sets the expand parameters for additional data.
+     *
+     * @param expand the expand parameters
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param start the start index
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest start(final int start) {
         this.start = start;
         return this;
     }
 
+    /**
+     * Sets the limit for pagination.
+     *
+     * @param limit the limit
+     * @return this request instance for method chaining
+     */
     public GetContentsRequest limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing content list
+     */
     public GetContentsResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -93,6 +171,12 @@ public class GetContentsRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a GetContentsResponse object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     */
     public static GetContentsResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetContentsResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentsResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/GetContentsResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Content;
 
+/**
+ * Response for GetContentsRequest containing a list of Confluence content.
+ */
 public class GetContentsResponse {
 
+    /** The list of content items. */
     protected final List<Content> contents;
 
+    /**
+     * Constructs a response with the given content list.
+     *
+     * @param contents the list of content items
+     */
     public GetContentsResponse(final List<Content> contents) {
         this.contents = contents;
     }
 
+    /**
+     * Gets the list of content items.
+     *
+     * @return the list of content items
+     */
     public List<Content> getContents() {
         return contents;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetAttachmentsOfContentRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetAttachmentsOfContentRequest.java
@@ -31,6 +31,10 @@ import org.codelibs.fess.ds.atlassian.api.confluence.domain.Attachment;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request class for retrieving attachments of Confluence content.
+ * Allows filtering and pagination of attachment results.
+ */
 public class GetAttachmentsOfContentRequest extends AtlassianRequest {
 
     private final String id;
@@ -40,35 +44,76 @@ public class GetAttachmentsOfContentRequest extends AtlassianRequest {
     private String mediaType;
     private String[] expand;
 
+    /**
+     * Constructs a request to get attachments for the specified content ID.
+     *
+     * @param id the content ID
+     */
     public GetAttachmentsOfContentRequest(final String id) {
         this.id = id;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param start the start index
+     * @return this request instance for method chaining
+     */
     public GetAttachmentsOfContentRequest start(final int start) {
         this.start = start;
         return this;
     }
 
+    /**
+     * Sets the maximum number of attachments to return.
+     *
+     * @param limit the maximum number of results
+     * @return this request instance for method chaining
+     */
     public GetAttachmentsOfContentRequest limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Filters attachments by filename.
+     *
+     * @param filename the filename to filter by
+     * @return this request instance for method chaining
+     */
     public GetAttachmentsOfContentRequest filename(final String filename) {
         this.filename = filename;
         return this;
     }
 
+    /**
+     * Filters attachments by media type.
+     *
+     * @param mediaType the media type to filter by
+     * @return this request instance for method chaining
+     */
     public GetAttachmentsOfContentRequest mediaType(final String mediaType) {
         this.mediaType = mediaType;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetAttachmentsOfContentRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing attachments
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetAttachmentsOfContentResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -80,6 +125,13 @@ public class GetAttachmentsOfContentRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetAttachmentsOfContentResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetAttachmentsOfContentResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetAttachmentsOfContentResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetAttachmentsOfContentResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Attachment;
 
+/**
+ * Response containing a list of attachments from Confluence content.
+ */
 public class GetAttachmentsOfContentResponse {
 
+    /** The list of attachments returned by the API. */
     protected List<Attachment> attachments;
 
+    /**
+     * Constructs a response with the given list of attachments.
+     *
+     * @param attachments the list of attachments
+     */
     public GetAttachmentsOfContentResponse(final List<Attachment> attachments) {
         this.attachments = attachments;
     }
 
+    /**
+     * Returns the list of attachments.
+     *
+     * @return the list of attachments
+     */
     public List<Attachment> getAttachments() {
         return attachments;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetCommentsOfContentRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetCommentsOfContentRequest.java
@@ -32,6 +32,10 @@ import org.codelibs.fess.ds.atlassian.api.confluence.domain.Comment;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request class for retrieving comments of Confluence content.
+ * Allows filtering, pagination, and depth control for comment results.
+ */
 public class GetCommentsOfContentRequest extends AtlassianRequest {
 
     private final String id;
@@ -42,40 +46,87 @@ public class GetCommentsOfContentRequest extends AtlassianRequest {
     private String depth;
     private String[] expand;
 
+    /**
+     * Constructs a request to get comments for the specified content ID.
+     *
+     * @param id the content ID
+     */
     public GetCommentsOfContentRequest(final String id) {
         this.id = id;
     }
 
+    /**
+     * Sets the parent version to retrieve comments from.
+     *
+     * @param parentVersion the parent version number
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest parentVersion(final int parentVersion) {
         this.parentVersion = parentVersion;
         return this;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param start the start index
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest start(final int start) {
         this.start = start;
         return this;
     }
 
+    /**
+     * Sets the maximum number of comments to return.
+     *
+     * @param limit the maximum number of results
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Sets the location filter for comments.
+     *
+     * @param location the location to filter by
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest location(final String location) {
         this.location = location;
         return this;
     }
 
+    /**
+     * Sets the depth for retrieving nested comments.
+     *
+     * @param depth the depth level
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest depth(final String depth) {
         this.depth = depth;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetCommentsOfContentRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing comments
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetCommentsOfContentResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -87,6 +138,13 @@ public class GetCommentsOfContentRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetCommentsOfContentResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetCommentsOfContentResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetCommentsOfContentResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/content/child/GetCommentsOfContentResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Comment;
 
+/**
+ * Response containing a list of comments from Confluence content.
+ */
 public class GetCommentsOfContentResponse {
 
+    /** The list of comments returned by the API. */
     protected final List<Comment> comments;
 
+    /**
+     * Constructs a response with the given list of comments.
+     *
+     * @param comments the list of comments
+     */
     public GetCommentsOfContentResponse(final List<Comment> comments) {
         this.comments = comments;
     }
 
+    /**
+     * Returns the list of comments.
+     *
+     * @return the list of comments
+     */
     public List<Comment> getComments() {
         return comments;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Attachment.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Attachment.java
@@ -21,32 +21,72 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Represents a file attachment in Confluence content.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Attachment {
 
+    /** The title of the attachment. */
     protected String title;
+
+    /** The media type of the attachment. */
     @JsonIgnore
     protected String mediaType;
+
+    /** The download link for the attachment. */
     @JsonIgnore
     protected String downloadLink;
 
+    /**
+     * Default constructor for Attachment.
+     */
+    public Attachment() {
+        // Default constructor
+    }
+
+    /**
+     * Gets the attachment title.
+     *
+     * @return the attachment title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Gets the media type of the attachment.
+     *
+     * @return the media type
+     */
     public String getMediaType() {
         return mediaType;
     }
 
+    /**
+     * Gets the download link for the attachment.
+     *
+     * @return the download link
+     */
     public String getDownloadLink() {
         return downloadLink;
     }
 
+    /**
+     * Unpacks metadata from the API response.
+     *
+     * @param metadata the metadata from API response
+     */
     @JsonProperty("metadata")
     public void unpackMetadata(final Map<String, Object> metadata) {
         this.mediaType = (String) metadata.get("mediaType");
     }
 
+    /**
+     * Unpacks links from the API response.
+     *
+     * @param links the links from API response
+     */
     @JsonProperty("_links")
     public void unpackLinks(final Map<String, Object> links) {
         this.downloadLink = (String) links.get("download");

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Comment.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Comment.java
@@ -21,21 +21,49 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Represents a comment on Confluence content.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Comment {
 
+    /** The title of the comment. */
     protected String title;
+
+    /** The body content of the comment. */
     @JsonIgnore
     protected String body;
 
+    /**
+     * Default constructor for Comment.
+     */
+    public Comment() {
+        // Default constructor
+    }
+
+    /**
+     * Gets the comment title.
+     *
+     * @return the comment title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Gets the comment body.
+     *
+     * @return the comment body
+     */
     public String getBody() {
         return body;
     }
 
+    /**
+     * Unpacks the body content from the API response.
+     *
+     * @param body the body data from API response
+     */
     @JsonProperty("body")
     public void unpackBody(final Map<String, Object> body) {
         @SuppressWarnings("unchecked")

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Content.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Content.java
@@ -24,43 +24,98 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Represents content in Confluence (e.g., pages, blog posts).
+ * Contains metadata and body content with version information.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Content {
 
+    /** The unique identifier of the content. */
     protected String id;
+
+    /** The type of content (e.g., page, blogpost). */
     protected String type;
+
+    /** The title of the content. */
     protected String title;
+
+    /** The space containing this content. */
     protected Space space;
 
+    /** The body content in HTML format. */
     @JsonIgnore
     protected String body;
+
+    /** The last modified timestamp. */
     @JsonIgnore
     protected Long lastModified;
 
+    /**
+     * Default constructor.
+     */
+    public Content() {
+    }
+
+    /**
+     * Gets the content ID.
+     *
+     * @return the content ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the content type.
+     *
+     * @return the content type
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Gets the content title.
+     *
+     * @return the content title
+     */
     public String getTitle() {
         return title;
     }
 
+    /**
+     * Gets the space containing this content.
+     *
+     * @return the space
+     */
     public Space getSpace() {
         return space;
     }
 
+    /**
+     * Gets the content body.
+     *
+     * @return the content body in HTML format
+     */
     public String getBody() {
         return body;
     }
 
+    /**
+     * Gets the last modified timestamp.
+     *
+     * @return the last modified timestamp in milliseconds
+     */
     public Long getLastModified() {
         return lastModified;
     }
 
+    /**
+     * Unpacks the body content from the API response.
+     *
+     * @param body the body data from API response
+     */
     @JsonProperty("body")
     public void unpackBody(final Map<String, Object> body) {
         @SuppressWarnings("unchecked")
@@ -69,6 +124,12 @@ public class Content {
         this.body = value;
     }
 
+    /**
+     * Unpacks version information from the API response.
+     *
+     * @param version the version data from API response
+     * @throws ParseException if the date format cannot be parsed
+     */
     @JsonProperty("version")
     public void unpackVersion(final Map<String, Object> version) throws ParseException {
         final String when = (String) version.get("when");

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Space.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Space.java
@@ -17,21 +17,51 @@ package org.codelibs.fess.ds.atlassian.api.confluence.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents a Confluence space.
+ * Contains space metadata including key, name, and description.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Space {
 
+    /** The space key. */
     protected String key;
+
+    /** The space name. */
     protected String name;
+
+    /** The space description. */
     protected String description;
 
+    /**
+     * Default constructor.
+     */
+    public Space() {
+    }
+
+    /**
+     * Gets the space key.
+     *
+     * @return the space key
+     */
     public String getKey() {
         return key;
     }
 
+    /**
+     * Gets the space name.
+     *
+     * @return the space name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the space description.
+     *
+     * @return the space description
+     */
     public String getDescription() {
         return description;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpaceRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpaceRequest.java
@@ -26,20 +26,41 @@ import org.codelibs.fess.ds.atlassian.AtlassianDataStoreException;
 import org.codelibs.fess.ds.atlassian.api.AtlassianRequest;
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Space;
 
+/**
+ * Request class for retrieving a specific Confluence space.
+ * Allows expansion of space properties.
+ */
 public class GetSpaceRequest extends AtlassianRequest {
 
     private final String spaceKey;
     private String[] expand;
 
+    /**
+     * Constructs a request to get a specific Confluence space.
+     *
+     * @param spaceKey the space key
+     */
     public GetSpaceRequest(final String spaceKey) {
         this.spaceKey = spaceKey;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetSpaceRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing the space
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetSpaceResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -51,6 +72,13 @@ public class GetSpaceRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetSpaceResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetSpaceResponse(null);

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpaceResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpaceResponse.java
@@ -17,14 +17,28 @@ package org.codelibs.fess.ds.atlassian.api.confluence.space;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Space;
 
+/**
+ * Response containing a Confluence space.
+ */
 public class GetSpaceResponse {
 
+    /** The space returned by the API. */
     protected Space space;
 
+    /**
+     * Constructs a response with the given space.
+     *
+     * @param space the space
+     */
     public GetSpaceResponse(final Space space) {
         this.space = space;
     }
 
+    /**
+     * Returns the space.
+     *
+     * @return the space
+     */
     public Space getSpace() {
         return space;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpacesRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpacesRequest.java
@@ -31,6 +31,11 @@ import org.codelibs.fess.ds.atlassian.api.confluence.domain.Space;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request class for retrieving multiple Confluence spaces.
+ * Supports filtering by space key, type, status, label, and favorite status.
+ * Also supports pagination and field expansion.
+ */
 public class GetSpacesRequest extends AtlassianRequest {
 
     private String spaceKey;
@@ -42,46 +47,107 @@ public class GetSpacesRequest extends AtlassianRequest {
     private Integer start;
     private Integer limit;
 
+    /**
+     * Default constructor for GetSpacesRequest.
+     */
+    public GetSpacesRequest() {
+        // Default constructor
+    }
+
+    /**
+     * Sets the space key filter.
+     *
+     * @param spaceKey the space key to filter by
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest spaceKey(final String spaceKey) {
         this.spaceKey = spaceKey;
         return this;
     }
 
+    /**
+     * Sets the space type filter.
+     *
+     * @param type the space type to filter by
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest type(final String type) {
         this.type = type;
         return this;
     }
 
+    /**
+     * Sets the space status filter.
+     *
+     * @param status the space status to filter by
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest status(final String status) {
         this.status = status;
         return this;
     }
 
+    /**
+     * Sets the label filter.
+     *
+     * @param label the label to filter by
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest label(final String label) {
         this.label = label;
         return this;
     }
 
+    /**
+     * Sets the favourite filter.
+     *
+     * @param favourite the favourite status to filter by
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest favourite(final String favourite) {
         this.favourite = favourite;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param start the start index
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest start(final int start) {
         this.start = start;
         return this;
     }
 
+    /**
+     * Sets the maximum number of spaces to return.
+     *
+     * @param limit the maximum number of results
+     * @return this request instance for method chaining
+     */
     public GetSpacesRequest limit(final int limit) {
         this.limit = limit;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing spaces
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetSpacesResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -93,6 +159,13 @@ public class GetSpacesRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetSpacesResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetSpacesResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpacesResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/space/GetSpacesResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.confluence.domain.Space;
 
+/**
+ * Response containing a list of Confluence spaces.
+ */
 public class GetSpacesResponse {
 
+    /** The list of spaces returned by the API. */
     protected List<Space> spaces;
 
+    /**
+     * Constructs a response with the given list of spaces.
+     *
+     * @param spaces the list of spaces
+     */
     public GetSpacesResponse(final List<Space> spaces) {
         this.spaces = spaces;
     }
 
+    /**
+     * Returns the list of spaces.
+     *
+     * @return the list of spaces
+     */
     public List<Space> getSpaces() {
         return spaces;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/JiraClient.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/JiraClient.java
@@ -31,18 +31,36 @@ import org.codelibs.fess.ds.atlassian.api.jira.search.SearchRequest;
 import org.codelibs.fess.ds.atlassian.api.jira.search.SearchResponse;
 import org.codelibs.fess.entity.DataStoreParams;
 
+/**
+ * JIRA API client for accessing JIRA projects, issues, and comments.
+ * Provides high-level methods for interacting with JIRA REST API.
+ */
 public class JiraClient extends AtlassianClient implements Closeable {
 
+    /** Default maximum number of issues to retrieve per request. */
     protected static final String DEFAULT_ISSUE_MAX_RESULTS = "50";
 
     // parameters for Jira
+    /** Parameter key for JQL query configuration. */
     protected static final String JQL_PARAM = "issue.jql";
+
+    /** Parameter key for issue max results configuration. */
     protected static final String ISSUE_MAX_RESULTS_PARAM = "issue_max_results";
 
+    /** The JIRA instance home URL. */
     protected final String jiraHome;
+
+    /** The JQL query for filtering issues. */
     protected final String jql;
+
+    /** The maximum number of issues to retrieve per request. */
     protected final Integer issueMaxResults;
 
+    /**
+     * Constructs a new JIRA client with the specified parameters.
+     *
+     * @param paramMap the configuration parameters
+     */
     public JiraClient(final DataStoreParams paramMap) {
         super(paramMap);
         jiraHome = getHome(paramMap);
@@ -55,34 +73,79 @@ public class JiraClient extends AtlassianClient implements Closeable {
         // TODO
     }
 
+    /**
+     * Gets the JQL query from parameters.
+     *
+     * @param paramMap the parameter map
+     * @return the JQL query
+     */
     protected String getJql(final DataStoreParams paramMap) {
         return paramMap.getAsString(JQL_PARAM);
     }
 
+    /**
+     * Gets the issue max results from parameters.
+     *
+     * @param paramMap the parameter map
+     * @return the issue max results
+     */
     protected Integer getIssueMaxResults(final DataStoreParams paramMap) {
         return Integer.parseInt(paramMap.getAsString(ISSUE_MAX_RESULTS_PARAM, DEFAULT_ISSUE_MAX_RESULTS));
     }
 
+    /**
+     * Gets the JIRA home URL.
+     *
+     * @return the JIRA home URL
+     */
     public String getJiraHome() {
         return jiraHome;
     }
 
+    /**
+     * Creates a request to get all projects.
+     *
+     * @return a GetProjectsRequest instance
+     */
     public GetProjectsRequest projects() {
         return createRequest(new GetProjectsRequest());
     }
 
+    /**
+     * Creates a request to get a specific project.
+     *
+     * @param projectIdOrKey the project ID or key
+     * @return a GetProjectRequest instance
+     */
     public GetProjectRequest project(final String projectIdOrKey) {
         return createRequest(new GetProjectRequest(projectIdOrKey));
     }
 
+    /**
+     * Creates a search request for issues.
+     *
+     * @return a SearchRequest instance
+     */
     public SearchRequest search() {
         return createRequest(new SearchRequest());
     }
 
+    /**
+     * Creates a request to get a specific issue.
+     *
+     * @param issueIdOrKey the issue ID or key
+     * @return a GetIssueRequest instance
+     */
     public GetIssueRequest issue(final String issueIdOrKey) {
         return createRequest(new GetIssueRequest(issueIdOrKey));
     }
 
+    /**
+     * Creates a request to get comments for a specific issue.
+     *
+     * @param issueIdOrKey the issue ID or key
+     * @return a GetCommentsRequest instance
+     */
     public GetCommentsRequest comments(final String issueIdOrKey) {
         return createRequest(new GetCommentsRequest(issueIdOrKey));
     }
@@ -92,6 +155,12 @@ public class JiraClient extends AtlassianClient implements Closeable {
         return jiraHome;
     }
 
+    /**
+     * Retrieves all issues using pagination and passes them to the consumer.
+     * Uses the configured JQL query to filter issues.
+     *
+     * @param consumer the consumer to process each issue
+     */
     public void getIssues(final Consumer<Issue> consumer) {
         int startAt = 0;
         while (true) {
@@ -105,6 +174,12 @@ public class JiraClient extends AtlassianClient implements Closeable {
         }
     }
 
+    /**
+     * Retrieves all comments for a specific issue using pagination and passes them to the consumer.
+     *
+     * @param issueId the issue ID
+     * @param consumer the consumer to process each comment
+     */
     public void getComments(final String issueId, final Consumer<Comment> consumer) {
         int startAt = 0;
         while (true) {

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comment.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comment.java
@@ -17,11 +17,27 @@ package org.codelibs.fess.ds.atlassian.api.jira.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents a comment on a JIRA issue.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Comment {
 
+    /** The body content of the comment. */
     protected String body;
 
+    /**
+     * Default constructor for Comment.
+     */
+    public Comment() {
+        // Default constructor
+    }
+
+    /**
+     * Gets the comment body.
+     *
+     * @return the comment body
+     */
     public String getBody() {
         return body;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comments.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comments.java
@@ -19,16 +19,39 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents a collection of comments in JIRA.
+ * This class contains the total count and list of comments.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Comments {
 
+    /** The total number of comments. */
     protected Long total;
+
+    /** The list of comment objects. */
     protected List<Comment> comments;
 
+    /**
+     * Default constructor.
+     */
+    public Comments() {
+    }
+
+    /**
+     * Gets the total number of comments.
+     *
+     * @return the total number of comments
+     */
     public Long getTotal() {
         return total;
     }
 
+    /**
+     * Gets the list of comments.
+     *
+     * @return the list of comments
+     */
     public List<Comment> getComments() {
         return comments;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Fields.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Fields.java
@@ -17,26 +17,63 @@ package org.codelibs.fess.ds.atlassian.api.jira.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents the fields of a JIRA issue.
+ * Contains essential information like summary, description, update time, and comments.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Fields {
 
+    /** The summary of the issue. */
     protected String summary;
+
+    /** The last updated timestamp of the issue. */
     protected String updated;
+
+    /** The description of the issue. */
     protected String description;
+
+    /** The comments associated with the issue. */
     protected Comments comment;
 
+    /**
+     * Default constructor.
+     */
+    public Fields() {
+    }
+
+    /**
+     * Gets the issue summary.
+     *
+     * @return the issue summary
+     */
     public String getSummary() {
         return summary;
     }
 
+    /**
+     * Gets the last updated timestamp.
+     *
+     * @return the last updated timestamp
+     */
     public String getUpdated() {
         return updated;
     }
 
+    /**
+     * Gets the issue description.
+     *
+     * @return the issue description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Gets the issue comments.
+     *
+     * @return the issue comments
+     */
     public Comments getComment() {
         return comment;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Issue.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Issue.java
@@ -17,31 +17,75 @@ package org.codelibs.fess.ds.atlassian.api.jira.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents a JIRA issue.
+ * Contains metadata and fields information for a JIRA issue.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Issue {
 
+    /** The unique identifier of the issue. */
     protected String id;
+
+    /** The self URL of the issue. */
     protected String self;
+
+    /** The expand parameter for additional information. */
     protected String expand;
+
+    /** The issue key (e.g., PROJECT-123). */
     protected String key;
+
+    /** The fields data of the issue. */
     protected Fields fields;
 
+    /**
+     * Default constructor.
+     */
+    public Issue() {
+    }
+
+    /**
+     * Gets the issue ID.
+     *
+     * @return the issue ID
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Gets the self URL of the issue.
+     *
+     * @return the self URL
+     */
     public String getSelf() {
         return self;
     }
 
+    /**
+     * Gets the expand parameter.
+     *
+     * @return the expand parameter
+     */
     public String getExpand() {
         return expand;
     }
 
+    /**
+     * Gets the issue key.
+     *
+     * @return the issue key
+     */
     public String getKey() {
         return key;
     }
 
+    /**
+     * Gets the issue fields.
+     *
+     * @return the issue fields
+     */
     public Fields getFields() {
         return fields;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Project.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Project.java
@@ -17,31 +17,75 @@ package org.codelibs.fess.ds.atlassian.api.jira.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Represents a JIRA project.
+ * Contains project metadata including ID, key, name, and description.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Project {
 
+    /** The self URL of the project. */
     protected String self;
+
+    /** The project key. */
     protected String key;
+
+    /** The unique identifier of the project. */
     protected Long id;
+
+    /** The project name. */
     protected String name;
+
+    /** The project description. */
     protected String description;
 
+    /**
+     * Default constructor.
+     */
+    public Project() {
+    }
+
+    /**
+     * Gets the self URL of the project.
+     *
+     * @return the self URL
+     */
     public String getSelf() {
         return self;
     }
 
+    /**
+     * Gets the project key.
+     *
+     * @return the project key
+     */
     public String getKey() {
         return key;
     }
 
+    /**
+     * Gets the project name.
+     *
+     * @return the project name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Gets the project ID.
+     *
+     * @return the project ID
+     */
     public Long getId() {
         return id;
     }
 
+    /**
+     * Gets the project description.
+     *
+     * @return the project description
+     */
     public String getDescription() {
         return description;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetCommentsRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetCommentsRequest.java
@@ -28,6 +28,10 @@ import org.codelibs.fess.ds.atlassian.AtlassianDataStoreException;
 import org.codelibs.fess.ds.atlassian.api.AtlassianRequest;
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Comments;
 
+/**
+ * Request class for retrieving comments from a JIRA issue.
+ * Supports pagination, ordering, and field expansion.
+ */
 public class GetCommentsRequest extends AtlassianRequest {
 
     private final String issueIdOrKey;
@@ -36,30 +40,65 @@ public class GetCommentsRequest extends AtlassianRequest {
     private String orderBy;
     private String[] expand;
 
+    /**
+     * Constructs a request to get comments for the specified JIRA issue.
+     *
+     * @param issueIdOrKey the issue ID or key
+     */
     public GetCommentsRequest(final String issueIdOrKey) {
         this.issueIdOrKey = issueIdOrKey;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param startAt the start index
+     * @return this request instance for method chaining
+     */
     public GetCommentsRequest startAt(final long startAt) {
         this.startAt = startAt;
         return this;
     }
 
+    /**
+     * Sets the maximum number of comments to return.
+     *
+     * @param maxResults the maximum number of results
+     * @return this request instance for method chaining
+     */
     public GetCommentsRequest maxResults(final int maxResults) {
         this.maxResults = maxResults;
         return this;
     }
 
+    /**
+     * Sets the ordering for the comments.
+     *
+     * @param orderBy the field to order by
+     * @return this request instance for method chaining
+     */
     public GetCommentsRequest orderBy(final String orderBy) {
         this.orderBy = orderBy;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetCommentsRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing comments
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetCommentsResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -71,6 +110,13 @@ public class GetCommentsRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetCommentsResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetCommentsResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetCommentsResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetCommentsResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Comment;
 
+/**
+ * Response containing a list of comments from a JIRA issue.
+ */
 public class GetCommentsResponse {
 
+    /** The list of comments returned by the API. */
     protected final List<Comment> comments;
 
+    /**
+     * Constructs a response with the given list of comments.
+     *
+     * @param comments the list of comments
+     */
     public GetCommentsResponse(final List<Comment> comments) {
         this.comments = comments;
     }
 
+    /**
+     * Returns the list of comments.
+     *
+     * @return the list of comments
+     */
     public List<Comment> getComments() {
         return comments;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetIssueRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetIssueRequest.java
@@ -28,6 +28,10 @@ import org.codelibs.fess.ds.atlassian.api.jira.domain.Issue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request class for retrieving a JIRA issue.
+ * Allows specification of fields, properties to expand, and custom properties.
+ */
 public class GetIssueRequest extends AtlassianRequest {
 
     private final String issueIdOrKey;
@@ -35,25 +39,54 @@ public class GetIssueRequest extends AtlassianRequest {
     private String[] expand;
     private String[] properties;
 
+    /**
+     * Constructs a request to get a specific JIRA issue.
+     *
+     * @param issueIdOrKey the issue ID or key
+     */
     public GetIssueRequest(final String issueIdOrKey) {
         this.issueIdOrKey = issueIdOrKey;
     }
 
+    /**
+     * Specifies which fields to include in the response.
+     *
+     * @param fields the fields to include
+     * @return this request instance for method chaining
+     */
     public GetIssueRequest fields(final String... fields) {
         this.fields = fields;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetIssueRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Specifies which custom properties to include in the response.
+     *
+     * @param properties the properties to include
+     * @return this request instance for method chaining
+     */
     public GetIssueRequest properties(final String... properties) {
         this.properties = properties;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing the issue
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetIssueResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -65,6 +98,13 @@ public class GetIssueRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetIssueResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetIssueResponse(null);

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetIssueResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/issue/GetIssueResponse.java
@@ -17,13 +17,27 @@ package org.codelibs.fess.ds.atlassian.api.jira.issue;
 
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Issue;
 
+/**
+ * Response containing a JIRA issue.
+ */
 public class GetIssueResponse {
+    /** The issue returned by the API. */
     protected final Issue issue;
 
+    /**
+     * Constructs a response with the given issue.
+     *
+     * @param issue the issue
+     */
     public GetIssueResponse(final Issue issue) {
         this.issue = issue;
     }
 
+    /**
+     * Returns the issue.
+     *
+     * @return the issue
+     */
     public Issue getIssue() {
         return issue;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectRequest.java
@@ -26,20 +26,41 @@ import org.codelibs.fess.ds.atlassian.AtlassianDataStoreException;
 import org.codelibs.fess.ds.atlassian.api.AtlassianRequest;
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Project;
 
+/**
+ * Request class for retrieving a specific JIRA project.
+ * Allows expansion of project properties.
+ */
 public class GetProjectRequest extends AtlassianRequest {
 
     private final String projectIdOrKey;
     private String[] expand;
 
+    /**
+     * Constructs a request to get a specific JIRA project.
+     *
+     * @param projectIdOrKey the project ID or key
+     */
     public GetProjectRequest(final String projectIdOrKey) {
         this.projectIdOrKey = projectIdOrKey;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetProjectRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing the project
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetProjectResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -51,6 +72,13 @@ public class GetProjectRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetProjectResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetProjectResponse(null);

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectResponse.java
@@ -17,14 +17,28 @@ package org.codelibs.fess.ds.atlassian.api.jira.project;
 
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Project;
 
+/**
+ * Response containing a JIRA project.
+ */
 public class GetProjectResponse {
 
+    /** The project returned by the API. */
     protected final Project project;
 
+    /**
+     * Constructs a response with the given project.
+     *
+     * @param project the project
+     */
     public GetProjectResponse(final Project project) {
         this.project = project;
     }
 
+    /**
+     * Returns the project.
+     *
+     * @return the project
+     */
     public Project getProject() {
         return project;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectsRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectsRequest.java
@@ -30,21 +30,50 @@ import org.codelibs.fess.ds.atlassian.api.jira.domain.Project;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+/**
+ * Request class for retrieving all JIRA projects.
+ * Supports expansion of project properties and filtering by recent projects.
+ */
 public class GetProjectsRequest extends AtlassianRequest {
 
     private String[] expand;
     private Integer recent;
 
+    /**
+     * Default constructor for GetProjectsRequest.
+     */
+    public GetProjectsRequest() {
+        // Default constructor
+    }
+
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public GetProjectsRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Sets the number of recent projects to return.
+     *
+     * @param recent the number of recent projects
+     * @return this request instance for method chaining
+     */
     public GetProjectsRequest recent(final int recent) {
         this.recent = recent;
         return this;
     }
 
+    /**
+     * Executes the request and returns the response.
+     *
+     * @return the response containing projects
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public GetProjectsResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {
@@ -56,6 +85,13 @@ public class GetProjectsRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static GetProjectsResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return new GetProjectsResponse(Collections.emptyList());

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectsResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/project/GetProjectsResponse.java
@@ -19,14 +19,28 @@ import java.util.List;
 
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Project;
 
+/**
+ * Response containing a list of JIRA projects.
+ */
 public class GetProjectsResponse {
 
+    /** The list of projects returned by the API. */
     protected final List<Project> projects;
 
+    /**
+     * Constructs a response with the given list of projects.
+     *
+     * @param projects the list of projects
+     */
     public GetProjectsResponse(final List<Project> projects) {
         this.projects = projects;
     }
 
+    /**
+     * Returns the list of projects.
+     *
+     * @return the list of projects
+     */
     public List<Project> getProjects() {
         return projects;
     }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/search/SearchRequest.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/search/SearchRequest.java
@@ -26,6 +26,10 @@ import org.codelibs.curl.CurlResponse;
 import org.codelibs.fess.ds.atlassian.AtlassianDataStoreException;
 import org.codelibs.fess.ds.atlassian.api.AtlassianRequest;
 
+/**
+ * Request class for searching JIRA issues using JQL (JIRA Query Language).
+ * Supports pagination, field selection, query validation, and result expansion.
+ */
 public class SearchRequest extends AtlassianRequest {
 
     private String jql;
@@ -35,36 +39,86 @@ public class SearchRequest extends AtlassianRequest {
     private String[] fields;
     private String[] expand;
 
+    /**
+     * Default constructor for SearchRequest.
+     */
+    public SearchRequest() {
+        // Default constructor
+    }
+
+    /**
+     * Sets the JQL query string.
+     *
+     * @param jql the JQL query
+     * @return this request instance for method chaining
+     */
     public SearchRequest jql(final String jql) {
         this.jql = jql;
         return this;
     }
 
+    /**
+     * Sets the start index for pagination.
+     *
+     * @param startAt the start index
+     * @return this request instance for method chaining
+     */
     public SearchRequest startAt(final int startAt) {
         this.startAt = startAt;
         return this;
     }
 
+    /**
+     * Sets the maximum number of results to return.
+     *
+     * @param maxResults the maximum number of results
+     * @return this request instance for method chaining
+     */
     public SearchRequest maxResults(final int maxResults) {
         this.maxResults = maxResults;
         return this;
     }
 
+    /**
+     * Sets whether to validate the JQL query.
+     *
+     * @param validateQuery true to validate the query, false otherwise
+     * @return this request instance for method chaining
+     */
     public SearchRequest validateQuery(final boolean validateQuery) {
         this.validateQuery = validateQuery;
         return this;
     }
 
+    /**
+     * Specifies which fields to include in the response.
+     *
+     * @param fields the fields to include
+     * @return this request instance for method chaining
+     */
     public SearchRequest fields(final String... fields) {
         this.fields = fields;
         return this;
     }
 
+    /**
+     * Specifies which properties to expand in the response.
+     *
+     * @param expand the properties to expand
+     * @return this request instance for method chaining
+     */
     public SearchRequest expand(final String... expand) {
         this.expand = expand;
         return this;
     }
 
+    /**
+     * Parses the JSON response into a response object.
+     *
+     * @param json the JSON response string
+     * @return the parsed response
+     * @throws AtlassianDataStoreException if parsing fails
+     */
     public static SearchResponse parseResponse(final String json) {
         if (StringUtil.isBlank(json)) {
             return SearchResponse.create(Collections.emptyList());
@@ -76,6 +130,12 @@ public class SearchRequest extends AtlassianRequest {
         }
     }
 
+    /**
+     * Executes the search request and returns the response.
+     *
+     * @return the response containing search results
+     * @throws AtlassianDataStoreException if the request fails
+     */
     public SearchResponse execute() {
         try (CurlResponse response = getCurlResponse(GET)) {
             if (response.getHttpStatusCode() != 200) {

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/search/SearchResponse.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/search/SearchResponse.java
@@ -21,20 +21,50 @@ import org.codelibs.fess.ds.atlassian.api.jira.domain.Issue;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+/**
+ * Response containing search results from JIRA.
+ * Contains the total number of matching issues and the issues themselves.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SearchResponse {
 
+    /** The total number of issues matching the search criteria. */
     protected Long total;
+
+    /** The list of issues returned by the search. */
     protected List<Issue> issues;
 
+    /**
+     * Default constructor for SearchResponse.
+     */
+    public SearchResponse() {
+        // Default constructor
+    }
+
+    /**
+     * Returns the total number of issues matching the search.
+     *
+     * @return the total number of matching issues
+     */
     public Long getTotal() {
         return total;
     }
 
+    /**
+     * Returns the list of issues.
+     *
+     * @return the list of issues
+     */
     public List<Issue> getIssues() {
         return issues;
     }
 
+    /**
+     * Creates a SearchResponse with the given list of issues.
+     *
+     * @param issues the list of issues
+     * @return a new SearchResponse instance
+     */
     public static SearchResponse create(final List<Issue> issues) {
         final SearchResponse response = new SearchResponse();
         response.issues = issues;

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/util/UrlUtil.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/util/UrlUtil.java
@@ -22,12 +22,24 @@ import java.util.Map;
 
 import org.codelibs.core.lang.StringUtil;
 
+/**
+ * Utility class for URL encoding, decoding, and query parameter manipulation.
+ */
 public class UrlUtil {
 
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private UrlUtil() {
         // do nothing
     }
 
+    /**
+     * URL-encodes the given character sequence using UTF-8 encoding.
+     *
+     * @param element the character sequence to encode
+     * @return the URL-encoded string, or null if input is null
+     */
     public static String encode(final CharSequence element) {
         if (element == null) {
             return null;
@@ -35,6 +47,12 @@ public class UrlUtil {
         return URLEncoder.encode(element.toString(), StandardCharsets.UTF_8);
     }
 
+    /**
+     * URL-decodes the given character sequence using UTF-8 encoding.
+     *
+     * @param element the character sequence to decode
+     * @return the URL-decoded string, or null if input is null
+     */
     public static String decode(final CharSequence element) {
         if (element == null) {
             return null;
@@ -42,6 +60,12 @@ public class UrlUtil {
         return URLDecoder.decode(element.toString(), StandardCharsets.UTF_8);
     }
 
+    /**
+     * Builds a query parameter string from a map of parameters.
+     *
+     * @param params the parameter map (key-value pairs)
+     * @return the query parameter string (without leading '?'), or empty string if params is null
+     */
     public static String buildQueryParameters(final Map<String, String> params) {
         if (params == null) {
             return StringUtil.EMPTY;


### PR DESCRIPTION
This pull request addresses and resolves JavaDoc warnings in multiple classes under the org.codelibs.fess.ds.atlassian package. The changes include corrections to malformed or incomplete JavaDoc comments to ensure proper formatting and tool compatibility. This contributes to better code documentation quality and eliminates JavaDoc-related build or IDE warnings.
