### PR TITLE
fix: handle ADF format in Jira API v3 description and comments

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/atlassian/JiraDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/JiraDataStore.java
@@ -20,6 +20,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
@@ -28,12 +29,14 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.exception.InterruptedRuntimeException;
+import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.Constants;
 import org.codelibs.fess.app.service.FailureUrlService;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
 import org.codelibs.fess.crawler.exception.MultipleCrawlingAccessException;
 import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.ds.atlassian.api.jira.JiraClient;
+import org.codelibs.fess.ds.atlassian.api.jira.domain.Comment;
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Issue;
 import org.codelibs.fess.ds.callback.IndexUpdateCallback;
 import org.codelibs.fess.entity.DataStoreParams;
@@ -45,7 +48,8 @@ import org.codelibs.fess.util.ComponentUtil;
 
 /**
  * Data store implementation for crawling JIRA issues.
- * Retrieves issues and their comments from JIRA instances and indexes them in Fess.
+ * Retrieves issues and their comments from JIRA instances and indexes them in
+ * Fess.
  */
 public class JiraDataStore extends AtlassianDataStore {
 
@@ -123,14 +127,14 @@ public class JiraDataStore extends AtlassianDataStore {
     /**
      * Processes a single JIRA issue and indexes it.
      *
-     * @param dataConfig the data configuration
-     * @param callback the index update callback
-     * @param configMap the configuration map
-     * @param paramMap the parameter map
-     * @param scriptMap the script map
+     * @param dataConfig     the data configuration
+     * @param callback       the index update callback
+     * @param configMap      the configuration map
+     * @param paramMap       the parameter map
+     * @param scriptMap      the script map
      * @param defaultDataMap the default data map
-     * @param client the JIRA client
-     * @param issue the issue to process
+     * @param client         the JIRA client
+     * @param issue          the issue to process
      */
     protected void processIssue(final DataConfig dataConfig, final IndexUpdateCallback callback, final Map<String, Object> configMap,
             final DataStoreParams paramMap, final Map<String, String> scriptMap, final Map<String, Object> defaultDataMap,
@@ -158,7 +162,7 @@ public class JiraDataStore extends AtlassianDataStore {
             final Map<String, Object> issueMap = new HashMap<>();
 
             issueMap.put(ISSUE_SUMMARY, issue.getFields().getSummary());
-            issueMap.put(ISSUE_DESCRIPTION, issue.getFields().getDescription());
+            issueMap.put(ISSUE_DESCRIPTION, getIssueDescription(issue));
             issueMap.put(ISSUE_COMMENTS, getIssueComments(issue, client));
             issueMap.put(ISSUE_LAST_MODIFIED, getIssueLastModified(issue));
             issueMap.put(ISSUE_VIEW_URL, url);
@@ -225,7 +229,7 @@ public class JiraDataStore extends AtlassianDataStore {
     /**
      * Gets the view URL for a JIRA issue.
      *
-     * @param issue the JIRA issue
+     * @param issue  the JIRA issue
      * @param client the JIRA client
      * @return the issue view URL
      */
@@ -236,7 +240,7 @@ public class JiraDataStore extends AtlassianDataStore {
     /**
      * Gets all comments for a JIRA issue as concatenated text.
      *
-     * @param issue the JIRA issue
+     * @param issue  the JIRA issue
      * @param client the JIRA client
      * @return the concatenated comments text
      */
@@ -246,7 +250,7 @@ public class JiraDataStore extends AtlassianDataStore {
 
         client.getComments(id, comment -> {
             sb.append("\n\n");
-            sb.append(getExtractedTextFromHtml(comment.getBody()));
+            sb.append(getCommentBodyText(comment));
         });
 
         return sb.toString();
@@ -268,6 +272,86 @@ public class JiraDataStore extends AtlassianDataStore {
             logger.warn("Failed to parse: {}", updated, e);
         }
         return null;
+    }
+
+    /**
+     * Gets the description of a JIRA issue as text.
+     *
+     * @param issue the JIRA issue
+     * @return the description text
+     */
+    protected String getIssueDescription(final Issue issue) {
+        final Object description = issue.getFields().getDescription();
+        if (description instanceof String) {
+            return (String) description;
+        } else if (description instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> adf = (Map<String, Object>) description;
+            return getExtractedTextFromAdf(adf);
+        }
+        return StringUtil.EMPTY;
+    }
+
+    /**
+     * Extracts text content from Atlassian Document Format (ADF) map.
+     *
+     * @param adf the ADF map
+     * @return the extracted text
+     */
+    protected String getExtractedTextFromAdf(final Map<String, Object> adf) {
+        final StringBuilder sb = new StringBuilder();
+        extractTextFromAdf(adf, sb);
+        return sb.toString().trim();
+    }
+
+    /**
+     * Recursively extracts text from ADF objects.
+     *
+     * @param obj the ADF object (Map or List)
+     * @param sb  the StringBuilder to append text to
+     */
+    @SuppressWarnings("unchecked")
+    protected void extractTextFromAdf(final Object obj, final StringBuilder sb) {
+        if (obj instanceof Map) {
+            final Map<String, Object> map = (Map<String, Object>) obj;
+            if (map.containsKey("text")) {
+                final Object text = map.get("text");
+                if (text != null) {
+                    sb.append(text.toString());
+                }
+            }
+            if (map.containsKey("content")) {
+                extractTextFromAdf(map.get("content"), sb);
+            }
+
+            final Object type = map.get("type");
+            if ("paragraph".equals(type) || "heading".equals(type)) {
+                sb.append("\n");
+            }
+        } else if (obj instanceof List) {
+            final List<Object> list = (List<Object>) obj;
+            for (final Object item : list) {
+                extractTextFromAdf(item, sb);
+            }
+        }
+    }
+
+    /**
+     * Gets the body text of a comment.
+     *
+     * @param comment the comment
+     * @return the body text
+     */
+    protected String getCommentBodyText(final Comment comment) {
+        final Object body = comment.getBody();
+        if (body instanceof String) {
+            return getExtractedTextFromHtml((String) body);
+        } else if (body instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> adf = (Map<String, Object>) body;
+            return getExtractedTextFromAdf(adf);
+        }
+        return StringUtil.EMPTY;
     }
 
 }

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Space.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/confluence/domain/Space.java
@@ -31,7 +31,7 @@ public class Space {
     protected String name;
 
     /** The space description. */
-    protected String description;
+    protected Object description;
 
     /**
      * Default constructor.
@@ -62,7 +62,7 @@ public class Space {
      *
      * @return the space description
      */
-    public String getDescription() {
+    public Object getDescription() {
         return description;
     }
 

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comment.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Comment.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class Comment {
 
     /** The body content of the comment. */
-    protected String body;
+    protected Object body;
 
     /**
      * Default constructor for Comment.
@@ -38,7 +38,7 @@ public class Comment {
      *
      * @return the comment body
      */
-    public String getBody() {
+    public Object getBody() {
         return body;
     }
 

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Fields.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Fields.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
  * Represents the fields of a JIRA issue.
- * Contains essential information like summary, description, update time, and comments.
+ * Contains essential information like summary, description, update time, and
+ * comments.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Fields {
@@ -31,7 +32,7 @@ public class Fields {
     protected String updated;
 
     /** The description of the issue. */
-    protected String description;
+    protected Object description;
 
     /** The comments associated with the issue. */
     protected Comments comment;
@@ -65,7 +66,7 @@ public class Fields {
      *
      * @return the issue description
      */
-    public String getDescription() {
+    public Object getDescription() {
         return description;
     }
 

--- a/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Project.java
+++ b/src/main/java/org/codelibs/fess/ds/atlassian/api/jira/domain/Project.java
@@ -37,7 +37,7 @@ public class Project {
     protected String name;
 
     /** The project description. */
-    protected String description;
+    protected Object description;
 
     /**
      * Default constructor.
@@ -86,7 +86,7 @@ public class Project {
      *
      * @return the project description
      */
-    public String getDescription() {
+    public Object getDescription() {
         return description;
     }
 

--- a/src/test/java/org/codelibs/fess/ds/atlassian/ConfluenceDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/atlassian/ConfluenceDataStoreTest.java
@@ -25,6 +25,7 @@ import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.atlassian.UnitDsTestCase;
+import org.junit.jupiter.api.Test;
 
 public class ConfluenceDataStoreTest extends UnitDsTestCase {
     public ConfluenceDataStore dataStore;
@@ -51,6 +52,7 @@ public class ConfluenceDataStoreTest extends UnitDsTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_storeData() {
         // doStoreDataTest();
     }

--- a/src/test/java/org/codelibs/fess/ds/atlassian/JiraDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/atlassian/JiraDataStoreTest.java
@@ -15,9 +15,10 @@
  */
 package org.codelibs.fess.ds.atlassian;
 
-import org.junit.jupiter.api.TestInfo;
-
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.codelibs.fess.ds.callback.IndexUpdateCallback;
@@ -25,6 +26,8 @@ import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.atlassian.UnitDsTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 public class JiraDataStoreTest extends UnitDsTestCase {
 
@@ -52,6 +55,7 @@ public class JiraDataStoreTest extends UnitDsTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_storeData() {
         // doStoreDataTest();
     }
@@ -96,5 +100,116 @@ public class JiraDataStoreTest extends UnitDsTestCase {
 
         dataStore.storeData(dataConfig, callback, paramMap, scriptMap, defaultDataMap);
 
+    }
+
+    @Test
+    public void test_getExtractedTextFromAdf_singleParagraph() {
+        final Map<String, Object> adf = new LinkedHashMap<>();
+        adf.put("type", "doc");
+        adf.put("version", 1);
+
+        final Map<String, Object> textNode = new LinkedHashMap<>();
+        textNode.put("type", "text");
+        textNode.put("text", "Hello World");
+
+        final Map<String, Object> paragraph = new LinkedHashMap<>();
+        paragraph.put("type", "paragraph");
+        paragraph.put("content", List.of(textNode));
+
+        adf.put("content", List.of(paragraph));
+
+        final String result = dataStore.getExtractedTextFromAdf(adf);
+        assertEquals("Hello World", result);
+    }
+
+    @Test
+    public void test_getExtractedTextFromAdf_multipleParagraphs() {
+        final Map<String, Object> adf = new LinkedHashMap<>();
+        adf.put("type", "doc");
+        adf.put("version", 1);
+
+        final Map<String, Object> text1 = new LinkedHashMap<>();
+        text1.put("type", "text");
+        text1.put("text", "First paragraph");
+
+        final Map<String, Object> para1 = new LinkedHashMap<>();
+        para1.put("type", "paragraph");
+        para1.put("content", List.of(text1));
+
+        final Map<String, Object> text2 = new LinkedHashMap<>();
+        text2.put("type", "text");
+        text2.put("text", "Second paragraph");
+
+        final Map<String, Object> para2 = new LinkedHashMap<>();
+        para2.put("type", "paragraph");
+        para2.put("content", List.of(text2));
+
+        adf.put("content", List.of(para1, para2));
+
+        final String result = dataStore.getExtractedTextFromAdf(adf);
+        assertEquals("First paragraph\nSecond paragraph", result);
+    }
+
+    @Test
+    public void test_getExtractedTextFromAdf_withHeading() {
+        final Map<String, Object> adf = new LinkedHashMap<>();
+        adf.put("type", "doc");
+        adf.put("version", 1);
+
+        final Map<String, Object> headingText = new LinkedHashMap<>();
+        headingText.put("type", "text");
+        headingText.put("text", "Title");
+
+        final Map<String, Object> heading = new LinkedHashMap<>();
+        heading.put("type", "heading");
+        heading.put("content", List.of(headingText));
+
+        final Map<String, Object> paraText = new LinkedHashMap<>();
+        paraText.put("type", "text");
+        paraText.put("text", "Body text");
+
+        final Map<String, Object> paragraph = new LinkedHashMap<>();
+        paragraph.put("type", "paragraph");
+        paragraph.put("content", List.of(paraText));
+
+        adf.put("content", List.of(heading, paragraph));
+
+        final String result = dataStore.getExtractedTextFromAdf(adf);
+        assertEquals("Title\nBody text", result);
+    }
+
+    @Test
+    public void test_getExtractedTextFromAdf_emptyDoc() {
+        final Map<String, Object> adf = new LinkedHashMap<>();
+        adf.put("type", "doc");
+        adf.put("version", 1);
+        adf.put("content", new ArrayList<>());
+
+        final String result = dataStore.getExtractedTextFromAdf(adf);
+        assertEquals("", result);
+    }
+
+    @Test
+    public void test_getExtractedTextFromAdf_multipleTextNodesInParagraph() {
+        final Map<String, Object> adf = new LinkedHashMap<>();
+        adf.put("type", "doc");
+        adf.put("version", 1);
+
+        final Map<String, Object> text1 = new LinkedHashMap<>();
+        text1.put("type", "text");
+        text1.put("text", "Hello ");
+
+        final Map<String, Object> text2 = new LinkedHashMap<>();
+        text2.put("type", "text");
+        text2.put("text", "World");
+
+        final Map<String, Object> paragraph = new LinkedHashMap<>();
+        paragraph.put("type", "paragraph");
+        paragraph.put("content", List.of(text1, text2));
+
+        adf.put("content", List.of(paragraph));
+
+        final String result = dataStore.getExtractedTextFromAdf(adf);
+        assertEquals("Hello World", result);
     }
 }

--- a/src/test/java/org/codelibs/fess/ds/atlassian/api/AtlassianClientTest.java
+++ b/src/test/java/org/codelibs/fess/ds/atlassian/api/AtlassianClientTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.TestInfo;
 
 import org.codelibs.fess.util.ComponentUtil;
 import org.codelibs.fess.ds.atlassian.UnitDsTestCase;
+import org.junit.jupiter.api.Test;
 
 public class AtlassianClientTest extends UnitDsTestCase {
 
@@ -49,6 +50,7 @@ public class AtlassianClientTest extends UnitDsTestCase {
         super.tearDown(testInfo);
     }
 
+    @Test
     public void test_production() {
         // doProductionTest();
     }

--- a/src/test/java/org/codelibs/fess/ds/atlassian/api/confluence/ConfluenceClientTest.java
+++ b/src/test/java/org/codelibs/fess/ds/atlassian/api/confluence/ConfluenceClientTest.java
@@ -34,6 +34,7 @@ import org.codelibs.fess.ds.atlassian.api.confluence.space.GetSpacesRequest;
 import org.codelibs.fess.ds.atlassian.api.confluence.space.GetSpacesResponse;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
+import org.junit.jupiter.api.Test;
 
 public class ConfluenceClientTest extends AtlassianClientTest {
     protected final String confluenceHome = "";
@@ -63,6 +64,7 @@ public class ConfluenceClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getContents_parseResponse() {
         final String json = "{" + //
                 "  \"results\": [{" + //
@@ -107,6 +109,7 @@ public class ConfluenceClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getCommentsOfContent_parseResponse() {
         String json = "{" + //
                 "  \"results\": [" + //
@@ -142,6 +145,7 @@ public class ConfluenceClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getAttachmentsOfContent_parseResponse() {
         String json = "{" + //
                 "  \"results\": [" + //
@@ -170,6 +174,7 @@ public class ConfluenceClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getSpaces_parseResponse() {
         final String json = "{" + //
                 "  \"results\": [" + //
@@ -189,6 +194,7 @@ public class ConfluenceClientTest extends AtlassianClientTest {
         // TODO
     }
 
+    @Test
     public void test_getSpace_parseResponse() {
         // TODO
     }

--- a/src/test/java/org/codelibs/fess/ds/atlassian/api/jira/JiraClientTest.java
+++ b/src/test/java/org/codelibs/fess/ds/atlassian/api/jira/JiraClientTest.java
@@ -18,6 +18,7 @@ package org.codelibs.fess.ds.atlassian.api.jira;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Map;
 
 import org.codelibs.fess.ds.atlassian.api.AtlassianClientTest;
 import org.codelibs.fess.ds.atlassian.api.jira.domain.Comment;
@@ -32,6 +33,7 @@ import org.codelibs.fess.ds.atlassian.api.jira.search.SearchRequest;
 import org.codelibs.fess.ds.atlassian.api.jira.search.SearchResponse;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.opensearch.config.exentity.DataConfig;
+import org.junit.jupiter.api.Test;
 
 public class JiraClientTest extends AtlassianClientTest {
 
@@ -57,6 +59,7 @@ public class JiraClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getProjects_parseResponse() {
         String json = "[{" + //
                 "    \"name\": \"Project-0\"" + //
@@ -98,6 +101,7 @@ public class JiraClientTest extends AtlassianClientTest {
         });
     }
 
+    @Test
     public void test_search_parseResponse() {
         final String json = "{" + //
                 "  \"total\": 2," + //
@@ -135,7 +139,7 @@ public class JiraClientTest extends AtlassianClientTest {
             assertTrue(fields.getSummary().startsWith("Summary-"));
             final long totalComments = fields.getComment().getTotal();
             final List<Comment> comments = fields.getComment().getComments();
-            assertEquals(comments.size(), totalComments);
+            assertEquals((long) comments.size(), totalComments);
             for (int j = 0; j < comments.size(); j++) {
                 final Comment comment = comments.get(j);
                 assertEquals(comment.getBody(), "Comment-" + i + "-" + j);
@@ -154,6 +158,7 @@ public class JiraClientTest extends AtlassianClientTest {
         }
     }
 
+    @Test
     public void test_getComments_parseResponse() {
         final String json = "{" + //
                 "  \"total\": 1," + //
@@ -168,6 +173,111 @@ public class JiraClientTest extends AtlassianClientTest {
             final Comment comment = comments.get(i);
             assertEquals(comment.getBody(), "Comment-" + i);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_search_parseResponse_withAdfDescription() {
+        final String json = "{" + //
+                "  \"total\": 1," + //
+                "  \"issues\": [{" + //
+                "      \"fields\": {" + //
+                "        \"summary\": \"Task 1\"," + //
+                "        \"description\": {" + //
+                "          \"type\": \"doc\"," + //
+                "          \"version\": 1," + //
+                "          \"content\": [{" + //
+                "            \"type\": \"paragraph\"," + //
+                "            \"content\": [{" + //
+                "              \"type\": \"text\"," + //
+                "              \"text\": \"This is a description.\"" + //
+                "            }]" + //
+                "          }]" + //
+                "        }," + //
+                "        \"updated\": \"2026-01-23T16:50:17.666+0900\"" + //
+                "      }," + //
+                "      \"key\": \"KAN-1\"" + //
+                "    }" + //
+                "  ]" + //
+                "}";
+        final SearchResponse response = SearchRequest.parseResponse(json);
+        final List<Issue> issues = response.getIssues();
+        assertEquals(1, issues.size());
+        final Issue issue = issues.get(0);
+        assertEquals("KAN-1", issue.getKey());
+        final Fields fields = issue.getFields();
+        assertEquals("Task 1", fields.getSummary());
+        assertTrue("description should be a Map", fields.getDescription() instanceof Map);
+        final Map<String, Object> adf = (Map<String, Object>) fields.getDescription();
+        assertEquals("doc", adf.get("type"));
+    }
+
+    @Test
+    public void test_search_parseResponse_withStringDescription() {
+        final String json = "{" + //
+                "  \"total\": 1," + //
+                "  \"issues\": [{" + //
+                "      \"fields\": {" + //
+                "        \"summary\": \"Task 2\"," + //
+                "        \"description\": \"Plain text description\"," + //
+                "        \"updated\": \"2026-01-23T16:50:17.666+0900\"" + //
+                "      }," + //
+                "      \"key\": \"KAN-2\"" + //
+                "    }" + //
+                "  ]" + //
+                "}";
+        final SearchResponse response = SearchRequest.parseResponse(json);
+        final List<Issue> issues = response.getIssues();
+        assertEquals(1, issues.size());
+        final Fields fields = issues.get(0).getFields();
+        assertTrue("description should be a String", fields.getDescription() instanceof String);
+        assertEquals("Plain text description", fields.getDescription());
+    }
+
+    @Test
+    public void test_search_parseResponse_withNullDescription() {
+        final String json = "{" + //
+                "  \"total\": 1," + //
+                "  \"issues\": [{" + //
+                "      \"fields\": {" + //
+                "        \"summary\": \"Task 3\"," + //
+                "        \"updated\": \"2026-01-23T16:50:17.666+0900\"" + //
+                "      }," + //
+                "      \"key\": \"KAN-3\"" + //
+                "    }" + //
+                "  ]" + //
+                "}";
+        final SearchResponse response = SearchRequest.parseResponse(json);
+        final List<Issue> issues = response.getIssues();
+        assertEquals(1, issues.size());
+        assertNull(issues.get(0).getFields().getDescription());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void test_getComments_parseResponse_withAdfBody() {
+        final String json = "{" + //
+                "  \"total\": 1," + //
+                "  \"comments\": [{" + //
+                "    \"body\": {" + //
+                "      \"type\": \"doc\"," + //
+                "      \"version\": 1," + //
+                "      \"content\": [{" + //
+                "        \"type\": \"paragraph\"," + //
+                "        \"content\": [{" + //
+                "          \"type\": \"text\"," + //
+                "          \"text\": \"ADF comment\"" + //
+                "        }]" + //
+                "      }]" + //
+                "    }" + //
+                "  }]" + //
+                "}";
+        final GetCommentsResponse response = GetCommentsRequest.parseResponse(json);
+        final List<Comment> comments = response.getComments();
+        assertEquals(1, comments.size());
+        assertTrue("body should be a Map", comments.get(0).getBody() instanceof Map);
+        final Map<String, Object> adf = (Map<String, Object>) comments.get(0).getBody();
+        assertEquals("doc", adf.get("type"));
     }
 
 }


### PR DESCRIPTION
## Summary
- Fix `MismatchedInputException` when crawling Jira issues with API v3, where `description` and `comment.body` are returned as Atlassian Document Format (ADF) JSON objects instead of plain strings
- Change `Fields.description`, `Comment.body`, `Project.description`, and `Space.description` types from `String` to `Object` to accept both formats
- Add recursive ADF-to-text extraction logic in `JiraDataStore` (`getIssueDescription`, `getCommentBodyText`, `extractTextFromAdf`)
- Add comprehensive tests for ADF parsing and text extraction

## Test plan
- [x] `mvn clean test` passes (22 tests, 0 failures)
- [x] ADF format description/comment parsing verified
- [x] String format backward compatibility verified
- [x] Null description handling verified